### PR TITLE
Enable admin_menu_toolbar by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       #
       # Avoiding a strange  runtime error with tripal_bulk_loader by NOT enabling  it for now
       #
-      TRIPAL_ENABLE_MODULES: "bootstrap maillog smtp jquery_update panels advanced_help page_manager tracker forum
+      TRIPAL_ENABLE_MODULES: "bootstrap maillog smtp jquery_update panels advanced_help page_manager tracker forum admin_menu
                              tripal_jbrowse tripal_galaxy brapi nd_genotypes genotypes_loader tripal_jbrowse_mgmt"
       #                      tripal_jbrowse tripal_galaxy brapi tripal_bulk_loader nd_genotypes genotypes_loader tripal_jbrowse_mgmt"
       THEME: "bootstrap"


### PR DESCRIPTION
admin_menu is much more convenient IMO.

Note I think overlay needs to be disabled to work.  Not sure if its enabled by default in these images or if it was enabled manually.  If so we can run pm-disable overlay in the post script...

![Screen Shot 2019-03-26 at 9 09 50 AM](https://user-images.githubusercontent.com/7063154/54999591-f11ebe00-4fa6-11e9-82db-173eb0af78a1.png)
